### PR TITLE
Added S3 prefix, fixed mongo CLI params

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,19 +12,19 @@
 
 ## Usage
 
-`bash /path/to/backup.sh -u MONGODB_USER -p MONGODB_PASSWORD -k AWS_ACCESS_KEY -s AWS_SECRET_KEY -r S3_REGION -b S3_BUCKET`
+`bash /path/to/backup.sh -u MONGODB_USER -p MONGODB_PASSWORD -k AWS_ACCESS_KEY -s AWS_SECRET_KEY -r S3_REGION -b S3_BUCKET -x S3_PREFIX`
 
-Where `S3_REGION` is in the format `ap-southeast-1`
+Where `S3_REGION` is in the format `ap-southeast-1` and `S3_PREFIX` can be used as folder path `foo/bar/`
 
 ## Cron
 
 ### Daily
 
-Add the following line to `/etc/cron.d/db-backup` to run the script every day at midnight (UTC time) 
+Add the following line to `/etc/cron.d/db-backup` to run the script every day at midnight (UTC time)
 
     0 0 * * * root /bin/bash /path/to/backup.sh -u MONGODB_USER -p MONGODB_PASSWORD -k AWS_ACCESS_KEY -s AWS_SECRET_KEY -b S3_BUCKET
 
-# License 
+# License
 
 (The MIT License)
 


### PR DESCRIPTION
Added optional S3 prefix (to emulate folder structure), would address #4 

In my setup mongo and mongodump were very unhappy with `-useraname` and `-password` switched to using `-u` and `-p` instead.
