### PR TITLE
mongodump requires --username and --password now

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -85,7 +85,7 @@ ARCHIVE_NAME="$FILE_NAME.tar.gz"
 mongo -username "$MONGODB_USER" -password "$MONGODB_PASSWORD" admin --eval "var databaseNames = db.getMongo().getDBNames(); for (var i in databaseNames) { printjson(db.getSiblingDB(databaseNames[i]).getCollectionNames()) }; printjson(db.fsyncLock());"
 
 # Dump the database
-mongodump -username "$MONGODB_USER" -password "$MONGODB_PASSWORD" --out $DIR/backup/$FILE_NAME
+mongodump --username "$MONGODB_USER" --password "$MONGODB_PASSWORD" --out $DIR/backup/$FILE_NAME
 
 # Unlock the database
 mongo -username "$MONGODB_USER" -password "$MONGODB_PASSWORD" admin --eval "printjson(db.fsyncUnlock());"


### PR DESCRIPTION
Used to be -username and -password, was throwing an error about positional arguments.
